### PR TITLE
Support manual trigger of plugin through URL query parameter

### DIFF
--- a/src/ios/WebPProtocol.m
+++ b/src/ios/WebPProtocol.m
@@ -28,7 +28,7 @@
     NSURL* url = [request URL];
     NSString* const requestFiletype = [[url pathExtension] lowercaseString];
 
-    return [@"webp" isEqualToString:requestFiletype] || [[url absoluteString] hasPrefix:@"data:image/webp;"];
+    return [@"webp" isEqualToString:requestFiletype] || [[url absoluteString] hasPrefix:@"data:image/webp;"] || [[url query] containsString:@"aswebp=true"];
 }
 
 + (NSURLRequest *)canonicalRequestForRequest:(NSURLRequest *)request {

--- a/src/ios/WebPProtocol.m
+++ b/src/ios/WebPProtocol.m
@@ -28,7 +28,7 @@
     NSURL* url = [request URL];
     NSString* const requestFiletype = [[url pathExtension] lowercaseString];
 
-    return [@"webp" isEqualToString:requestFiletype] || [[url absoluteString] hasPrefix:@"data:image/webp;"] || [[url query] containsString:@"aswebp=true"];
+    return [@"webp" isEqualToString:requestFiletype] || [[url absoluteString] hasPrefix:@"data:image/webp;"] || [[url query] containsString:@"cdvwebp=true"];
 }
 
 + (NSURLRequest *)canonicalRequestForRequest:(NSURLRequest *)request {


### PR DESCRIPTION
This fixes issue #7 by allowing any URL to be manually marked as being a webp picture.
Feel free to reject the PR if you think this is a too specific use case.
